### PR TITLE
Add security policy for blocking unsolicited responses

### DIFF
--- a/shibboleth/security-policy.xml
+++ b/shibboleth/security-policy.xml
@@ -20,6 +20,22 @@
         <PolicyRule type="XMLSigning" errorFatal="true"/>
         <PolicyRule type="SimpleSigning" errorFatal="true"/>
     </Policy>
+	
+    <!-- 
+    Required for passing SPID compliance tests 16, 17 and 18.
+    This blocks uncorrelated responses with unspecified, 
+    missing or wrong inResponseTo response attribute
+    -->
+    <Policy id="blockUnsolicited" validate="false">
+        <PolicyRule type="MessageFlow" blockUnsolicited="true" checkReplay="true" expires="60" checkCorrelation="true"/>
+        <PolicyRule type="Conditions">
+            <PolicyRule type="Audience"/>
+        </PolicyRule>
+        <PolicyRule type="ClientCertAuth" errorFatal="true"/>
+        <PolicyRule type="XMLSigning" errorFatal="true"/>
+        <PolicyRule type="SimpleSigning" errorFatal="true"/>
+        <PolicyRule type="Bearer" blockUnsolicited="true"/>
+    </Policy>	
 
     <!--
     This policy is a place-holder for use of assertions in metadata

--- a/shibboleth/shibboleth2.xml
+++ b/shibboleth/shibboleth2.xml
@@ -17,6 +17,7 @@
         signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" encryption="false"
         authnContextClassRef="https://www.spid.gov.it/SpidL2" authnContextComparison="exact"
         NameIDFormat="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+	policyId="blockUnsolicited"
         cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
 
         <!--

--- a/shibboleth/shibboleth2.xml
+++ b/shibboleth/shibboleth2.xml
@@ -17,7 +17,7 @@
         signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" encryption="false"
         authnContextClassRef="https://www.spid.gov.it/SpidL2" authnContextComparison="exact"
         NameIDFormat="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-	policyId="blockUnsolicited"
+        policyId="blockUnsolicited"
         cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
 
         <!--


### PR DESCRIPTION
This PR allows passing SPID compliance tests 16, 17 and 18 by blocking uncorrelated responses with unspecified, missing or wrong inResponseTo response attribute

Requires Shibboleth SP v3.1+ to work