### PR TITLE
Use Form Session Initiator

### DIFF
--- a/shibboleth/without-discovery-service/README.md
+++ b/shibboleth/without-discovery-service/README.md
@@ -1,0 +1,78 @@
+# Configuration for _Form_-based SessionInitiator
+
+This Shibboleth SP configuration represents an alternative to the base strategy, which **does not require an external Discovery Service**.
+
+__Note__: It represents just an example that should be customized on user needs.
+
+It uses the `Form` SessionInitiator functionality (https://wiki.shibboleth.net/confluence/display/SP3/Form+SessionInitiator) provided by Shibboleth SP which 
+allows configuring the SessionInitiator using a user-defined HTML form.
+
+The file [shibboleth2.xml](shibboleth2.xml) contains the example configuration where the only modifications w.r.t. the original one contained in this repo
+are the following:
+
+From:
+```
+            <SessionInitiator type="SAML2"
+                              id="Login"
+                              Location="/Login"
+                              isDefault="true"
+                              outgoingBinding="urn:oasis:names:tc:SAML:profiles:SSO:request-init"
+                              isPassive="false"
+                              acsIndex="0"
+                              acsByIndex="true"
+                              signing="true">
+                <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                    ID="id..."
+                                    Version="2.0"
+                                    IssueInstant="2017-01-01T00:00:00Z"
+                                    AttributeConsumingServiceIndex="0"
+                                    ForceAuthn="true">
+                    <!-- if NameQualifier is different from entityID, you need to update security-policy.xml -->
+                    <saml:Issuer NameQualifier="https://{sp_fqdn}/shibboleth"
+                                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+                    >https://{sp_fqdn}/shibboleth
+                    </saml:Issuer>
+                    <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"/>
+                </samlp:AuthnRequest>
+            </SessionInitiator>
+```
+
+To:
+```
+            <SessionInitiator type="Chaining" id="idpchooser" Location="/Login">
+               <SessionInitiator type="SAML2" 
+                                 id="Login" 
+                                 outgoingBinding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" 
+                                 isPassive="false" 
+                                 acsIndex="0" 
+                                 acsByIndex="true" 
+                                 signing="true">
+                  <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                    ID="id..."
+                                    Version="2.0"
+                                    IssueInstant="2017-01-01T00:00:00Z"
+                                    AttributeConsumingServiceIndex="0"
+                                    ForceAuthn="true">
+                     <!-- if NameQualifier is different from entityID, you need to update security-policy.xml -->
+                     <saml:Issuer NameQualifier="https://{sp_fqdn}/shibboleth"
+                                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+                     >https://{sp_fqdn}/shibboleth
+                     </saml:Issuer>
+                     <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" />
+                  </samlp:AuthnRequest>
+               </SessionInitiator>
+              
+               <SessionInitiator type="Form" template="discoveryTemplate.html" />
+            </SessionInitiator>          
+```
+
+### Explanation
+
+Instead of using just a basic `SAML2` SessionInitiator, a `Chaining` SessionInitiator is used. It wraps the standard `SAML2` initiator (where `isDefault="true"` 
+is absent) and the `Form` initiator, provided by an HTML file (in the example [discoveryTemplate.html](discoveryTemplate.html)) which contains the SPID button, 
+along with a few lines of JS code.
+
+Thus, as a Login Request is made, the Form template is shown to the user. Basing on their selection, the proper entityID for the 
+chosen IDP (which must be a known one) is set and the control is passed back to the SAML2 initiator, which continues SSO as usual.

--- a/shibboleth/without-discovery-service/discoveryTemplate.html
+++ b/shibboleth/without-discovery-service/discoveryTemplate.html
@@ -1,0 +1,106 @@
+<html>
+  <head>
+    <title>Request for Authentication</title>
+    <link type="text/css" rel="stylesheet" href="/css/spid-sp-access-button.min.css" />
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  </head>
+  <body>
+    <h1>Request for Authentication</h1>
+    <p>This web site requires you to login before proceeding. Please identify
+      the domain name of your organization:
+    </p>
+    <form method="GET" action="<shibmlp action/>" id="fm1">
+      <shibmlpif target>
+        <input type="hidden" name="target" value="<shibmlp target/>"/>
+      </shibmlpif>
+      <shibmlpif acsIndex>
+        <input type="hidden" name="acsIndex" value="<shibmlp acsIndex/>"/>
+      </shibmlpif>
+      <shibmlpif isPassive>
+        <input type="hidden" name="isPassive" value="<shibmlp isPassive/>"/>
+      </shibmlpif>
+      <shibmlpif forceAuthn>
+        <input type="hidden" name="forceAuthn" value="<shibmlp forceAuthn/>"/>
+      </shibmlpif>
+      <shibmlpif authnContextClassRef>
+        <input type="hidden" name="authnContextClassRef" value="<shibmlp authnContextClassRef/>"/>
+      </shibmlpif>
+      <shibmlpif authnContextDeclRef>
+        <input type="hidden" name="authnContextDeclRef" value="<shibmlp authnContextDeclRef/>"/>
+      </shibmlpif>
+      <shibmlpif authnContextComparison>
+        <input type="hidden" name="authnContextComparison" value="<shibmlp authnContextComparison/>"/>
+      </shibmlpif>
+      <input type="hidden" name="entityID" value="<shibmlp entityID/>" id="entityID">
+      <!--		    <input type="submit" value="Submit"/> -->
+      <!-- AGID - SPID IDP BUTTON LARGE "ENTRA CON SPID" * begin * -->
+      <a href="#" class="italia-it-button italia-it-button-size-m button-spid" spid-idp-button="#spid-idp-button-large-post" aria-haspopup="true" aria-expanded="false">
+      <span class="italia-it-button-icon"><img src="/img/spid-ico-circle-bb.svg" onerror="this.src='/img/spid-ico-circle-bb.png'; this.onerror=null;" alt="" /></span>
+      <span class="italia-it-button-text">Entra con SPID</span>
+      </a>
+      <div id="spid-idp-button-large-post" class="spid-idp-button spid-idp-button-tip spid-idp-button-relative">
+        <ul id="spid-idp-list-large-root-post" class="spid-idp-button-menu" aria-labelledby="spid-idp">
+          <li class="spid-idp-button-link" data-idp="arubaid">
+            <button entityID="https://loginspid.aruba.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Aruba ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-arubaid.svg" onerror="this.src='/img/spid-idp-arubaid.png'; this.onerror=null;" alt="Aruba ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="infocertid">
+            <button entityID="https://identity.infocert.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Infocert ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-infocertid.svg" onerror="this.src='/img/spid-idp-infocertid.png'; this.onerror=null;" alt="Infocert ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="posteid">
+            <button entityID="https://posteid.poste.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Poste ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-posteid.svg" onerror="this.src='/img/spid-idp-posteid.png'; this.onerror=null;" alt="Poste ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="sielteid">
+            <button entityID="https://identity.sieltecloud.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Sielte ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-sielteid.svg" onerror="this.src='/img/spid-idp-sielteid.png'; this.onerror=null;" alt="Sielte ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="timid">
+            <button entityID="https://login.id.tim.it/affwebservices/public/saml2sso" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-timid.svg" onerror="this.src='/img/spid-idp-timid.png'; this.onerror=null;" alt="Tim ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="intesaid">
+            <button entityID="https://spid.intesa.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-intesaid.svg" onerror="this.src='/img/spid-idp-intesaid.png'; this.onerror=null;" alt="Intesa ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="lepidaid">
+            <button entityID="https://id.lepida.it/idp/shibboleth" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-lepidaid.svg" onerror="this.src='/img/spid-idp-lepidaid.png'; this.onerror=null;" alt="Lepida ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="namirialid">
+            <button entityID="https://idp.namirialtsp.com/idp" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-namirialid.svg" onerror="this.src='/img/spid-idp-namirialid.png'; this.onerror=null;" alt="Namirial ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="registerid">
+            <button entityID="https://spid.register.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-spiditalia.svg" onerror="this.src='/img/spid-idp-spiditalia.png'; this.onerror=null;" alt="Register ID" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="validatorid">
+            <button entityID="https://validator.spid.gov.it" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-spidvalidator.svg" onerror="this.src='/img/spid-idp-spidvalidator.png'; this.onerror=null;" alt="ValidatorIDP" /></button>
+          </li>
+          <li class="spid-idp-button-link" data-idp="validatorid">
+            <button entityID="http://localhost:8080" class="idp-button-idp-logo" name="_eventId_ChooseMethodB" type="submit"><span class="spid-sr-only">Tim ID</span><img class="spid-idp-button-logo" src="/img/spid-idp-spidvalidator.svg" onerror="this.src='/img/spid-idp-spidvalidator.png'; this.onerror=null;" alt="ValidatorIDPLocal" /></button>
+          </li>
+        </ul>
+      </div>
+    </form>
+    <shibmlpif entityID>
+      <p>The system was unable to determine how to proceed using the value you supplied.</p>
+    </shibmlpif>
+    <script type="text/javascript" src="/js/spid-sp-access-button.min.js"></script>
+    <script>
+      $(document).ready(function(){
+         var rootList = $("#spid-idp-list-large-root-post");
+         var idpList = rootList.children(".spid-idp-button-link");
+         var lnkList = rootList.children(".spid-idp-support-link");
+         while (idpList.length) {
+             rootList.append(idpList.splice(Math.floor(Math.random() * idpList.length), 1)[0]);
+         }
+         rootList.append(lnkList);
+         $("#fm1").submit(function( event ) {
+           var entityID = $("button[type=submit][clicked=true]").attr('entityID');
+           $("#entityID").val(entityID);
+         });
+      
+         $("form button[type=submit]").click(function() {
+          $("button[type=submit]", $(this).parents("form")).removeAttr("clicked");
+          $(this).attr("clicked", "true");
+         });
+      
+      });
+      
+    </script>
+  </body>
+</html>

--- a/shibboleth/without-discovery-service/shibboleth2.xml
+++ b/shibboleth/without-discovery-service/shibboleth2.xml
@@ -1,0 +1,148 @@
+<SPConfig xmlns="urn:mace:shibboleth:3.0:native:sp:config"
+          xmlns:conf="urn:mace:shibboleth:3.0:native:sp:config"
+          xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+    clockSkew="180">
+
+    <OutOfProcess tranLogFormat="%u|%s|%IDP|%i|%ac|%t|%attr|%n|%b|%E|%S|%SS|%L|%UA|%a" />
+
+    <!--
+    By default, in-memory StorageService, ReplayCache, ArtifactMap, and SessionCache
+    are used. See example-shibboleth2.xml for samples of explicitly configuring them.
+    -->
+
+    <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
+    <ApplicationDefaults entityID="https://{sp_fqdn}/shibboleth"
+        REMOTE_USER="eppn subject-id pairwise-id persistent-id"
+        signing="true"
+        signingAlg="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" encryption="false"
+        authnContextClassRef="https://www.spid.gov.it/SpidL2" authnContextComparison="exact"
+        NameIDFormat="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+        policyId="blockUnsolicited"
+        cipherSuites="DEFAULT:!EXP:!LOW:!aNULL:!eNULL:!DES:!IDEA:!SEED:!RC4:!3DES:!kRSA:!SSLv2:!SSLv3:!TLSv1:!TLSv1.1">
+
+        <!--
+        Controls session lifetimes, address checks, cookie handling, and the protocol handlers.
+        Each Application has an effectively unique handlerURL, which defaults to "/Shibboleth.sso"
+        and should be a relative path, with the SP computing the full value based on the virtual
+        host. Using handlerSSL="true" will force the protocol to be https. You should also set
+        cookieProps to "https" for SSL-only sites. Note that while we default checkAddress to
+        "false", this makes an assertion stolen in transit easier for attackers to misuse.
+        -->
+        <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
+                  checkAddress="false" handlerSSL="true" cookieProps="https">
+
+            <!--
+            Configures SSO for a default IdP. To allow for >1 IdP, remove
+            entityID property and adjust discoveryURL to point to discovery service.
+            (Set discoveryProtocol to "WAYF" for legacy Shibboleth WAYF support.)
+            You can also override entityID on /Login query string, or in RequestMap/htaccess.
+            -->
+            <!-- Login
+            acsByIndex has to be true because explicit AssertionConsumerServiceURL
+            are not allowed -> error 16
+            for the same reason acsIndex is needed also if it is 0
+            -->
+
+            <SessionInitiator type="Chaining" id="idpchooser" Location="/Login">
+               <SessionInitiator type="SAML2" 
+                                 id="Login" 
+                                 outgoingBinding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" 
+                                 isPassive="false" 
+                                 acsIndex="0" 
+                                 acsByIndex="true" 
+                                 signing="true">
+                  <samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                    ID="id..."
+                                    Version="2.0"
+                                    IssueInstant="2017-01-01T00:00:00Z"
+                                    AttributeConsumingServiceIndex="0"
+                                    ForceAuthn="true">
+                     <!-- if NameQualifier is different from entityID, you need to update security-policy.xml -->
+                     <saml:Issuer NameQualifier="https://{sp_fqdn}/shibboleth"
+                                 Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+                    >https://{sp_fqdn}/shibboleth
+                    </saml:Issuer>
+                     <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" />
+                  </samlp:AuthnRequest>
+               </SessionInitiator>
+              
+               <SessionInitiator type="Form" template="discoveryTemplate.html" />
+            </SessionInitiator>          
+
+            <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                         Location="/SAML2/POST" index="0"/>
+
+            <!-- Logout -->
+            <LogoutInitiator type="Chaining" Location="/Logout">
+                <LogoutInitiator type="SAML2"
+                                 outgoingBindings="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                                 signing="true"/>
+                <LogoutInitiator type="Local" signing="true"/>
+            </LogoutInitiator>
+
+            <md:SingleLogoutService Location="/SLO/POST"
+                                    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"/>
+            <md:SingleLogoutService Location="/SLO/Redirect"
+                                    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"/>
+            <!-- Administrative logout. -->
+            <LogoutInitiator type="Admin" Location="/Logout/Admin" acl="127.0.0.1 ::1"/>
+
+            <!-- Extension service that generates "approximate" metadata based on SP configuration. -->
+            <Handler type="MetadataGenerator" Location="/Metadata" signing="true"/>
+
+            <!-- Status reporting service. -->
+            <Handler type="Status" Location="/Status" acl="127.0.0.1 ::1"/>
+
+            <!-- Session diagnostic service. -->
+            <Handler type="Session" Location="/Session" showAttributeValues="false"/>
+
+            <!-- JSON feed of discovery information. -->
+            <Handler type="DiscoveryFeed" Location="/DiscoFeed"/>
+        </Sessions>
+
+        <!--
+        Allows overriding of error template information/filenames. You can
+        also add your own attributes with values that can be plugged into the
+        templates, e.g., helpLocation below.
+        -->
+        <Errors supportContact="support@example.org"
+            helpLocation="/about.html"
+            styleSheet="/shibboleth-sp/main.css"/>
+
+        <!-- SPID Test Environment IdentityServer Metadata -->
+        <MetadataProvider type="XML" validate="true" path="metadata/spid-saml-check.xml" id="http://localhost:8080"/>
+	<!--
+        <MetadataProvider type="XML" validate="true" path="metadata/arubaid.xml" id="https://loginspid.aruba.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/infocertid.xml" id="https://identity.infocert.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/intesaid.xml" id="https://spid.intesa.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/namirialid.xml" id="https://idp.namirialtsp.com/idp"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/posteid.xml" id="https://posteid.poste.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/sielteid.xml" id="https://identity.sieltecloud.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/spiditalia.xml" id="https://spid.register.it"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/timid.xml" id="https://login.id.tim.it/affwebservices/public/saml2sso"/>
+        <MetadataProvider type="XML" validate="true" path="metadata/lepidaid.xml" id="https://id.lepida.it/idp/shibboleth"/>
+	-->
+
+        <!-- Map to extract attributes from SAML assertions. -->
+        <AttributeExtractor type="XML" validate="true" reloadChanges="false" path="attribute-map.xml"/>
+
+        <!-- Default filtering policy for recognized attributes, lets other data pass. -->
+        <AttributeFilter type="XML" validate="true" path="attribute-policy.xml"/>
+
+        <!-- Simple file-based resolvers for separate signing/encryption keys. -->
+        <CredentialResolver type="File" use="signing"
+            key="sp-key.pem" certificate="sp-cert.pem"/>
+        <!--
+        <CredentialResolver type="File" use="encryption"
+            key="sp-encrypt-key.pem" certificate="sp-encrypt-cert.pem"/>
+        -->
+    </ApplicationDefaults>
+
+    <!-- Policies that determine how to process and authenticate runtime messages. -->
+    <SecurityPolicyProvider type="XML" validate="true" path="security-policy.xml"/>
+
+    <!-- Low-level configuration about protocols and bindings available for use. -->
+    <ProtocolProvider type="XML" validate="true" reloadChanges="false" path="protocols.xml"/>
+
+</SPConfig>


### PR DESCRIPTION
This PR introduces an alternative configuration using Form-based SessionInitiator. It allows using an HTML file as a mean to let the user choose which IDP to use to start SSO.