### PR TITLE
Define checkAddress and explicit consistentAddress

### DIFF
--- a/shibboleth/shibboleth2.xml
+++ b/shibboleth/shibboleth2.xml
@@ -37,7 +37,7 @@
         "false", this makes an assertion stolen in transit easier for attackers to misuse.
         -->
         <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
-                  checkAddress="false" handlerSSL="true" cookieProps="https">
+                  checkAddress="false" consistentAddress="true" handlerSSL="true" cookieProps="https">
 
             <!--
             Configures SSO for a default IdP. To allow for >1 IdP, remove

--- a/shibboleth/without-discovery-service/shibboleth2.xml
+++ b/shibboleth/without-discovery-service/shibboleth2.xml
@@ -36,7 +36,7 @@
         "false", this makes an assertion stolen in transit easier for attackers to misuse.
         -->
         <Sessions lifetime="28800" timeout="3600" relayState="ss:mem"
-                  checkAddress="false" handlerSSL="true" cookieProps="https">
+                  checkAddress="false" consistentAddress="true" handlerSSL="true" cookieProps="https">
 
             <!--
             Configures SSO for a default IdP. To allow for >1 IdP, remove


### PR DESCRIPTION
CIE populates `<saml2:SubjectLocality />` and `<saml2:SubjectConfirmationData />` using an IP different from the client that made the request. Using `checkAddress="false"` solves the problem. However, to prevent cookie theft is suggested to use also `consistentAddress="true"`. This setting is true by default, but perhaps it is a good idea to make it explicit.